### PR TITLE
Make limit value numeric to support newer versions of mongoose.

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ Query.prototype.paginate = function(options, callback) {
   model.count(query._conditions, function(err, count) {
     var _skip = (options.page - 1) * options.perPage;
     _skip += options.offset;
-    query.skip(_skip).limit(options.perPage).exec(function(err, results) {
+    query.skip(_skip).limit(+options.perPage).exec(function(err, results) {
       if (err) {
         callback(err, {});
         return;


### PR DESCRIPTION
With version 1.0.1, an error would occur when setting limit in the query. The error was because query-paginate didn't cast the value as numeric.

This pull request simply casts the value as numeric to allow the library to work with the latest version of mongoose (4.6.5).