### PR TITLE
2.0: Upgrade Pagination to async await, Callback removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@
       //};
     });
 
+## Migration from v1.x to v2
+
+Instead of using callbacks, the paginate method now returns a promise.
+
+So it becomes:
+
+```js
+const pager = await query.paginate(options);
+```
+
 ## License
 
 The MIT License

--- a/index.js
+++ b/index.js
@@ -25,16 +25,16 @@ Query.prototype.paginate = async function (options) {
   const query = this;
   const model = query.model;
 
-  const count = await model.count(query._conditions);
+  const count = await model.countDocuments(query._conditions);
   const _skip = (options.page - 1) * options.perPage + options.offset;
-  const results = await query.skip(_skip).limit(+options.perPage).exec();
+  let results = await query.skip(_skip).limit(+options.perPage).exec();
 
   results = results || [];
   const page = parseInt(options.page, 10) || 0;
   const delta = options.delta;
   let offset_count = count - options.offset;
   offset_count = offset_count > 0 ? offset_count : 0;
-  const last = Math.ceil(offset_count / options.perPage);
+  let last = Math.ceil(offset_count / options.perPage);
   const current = page;
   const start = page - delta > 1 ? page - delta : 1;
   const end = current + delta + 1 < last ? current + delta : last;
@@ -44,8 +44,8 @@ Query.prototype.paginate = async function (options) {
     pages.push(i);
   }
 
-  const prev = !count || current == start ? null : current - 1;
-  const next = !count || current == end ? null : current + 1;
+  let prev = !count || current == start ? null : current - 1;
+  let next = !count || current == end ? null : current + 1;
   if (!offset_count) {
     prev = next = last = null;
   }

--- a/index.js
+++ b/index.js
@@ -1,19 +1,19 @@
 /**
  * mongoose-query-paginate
  */
-var Query = require('mongoose').Query;
+var Query = require("mongoose").Query;
 
 /**
  * paginate
  *
  * @param {Object} options
  */
-Query.prototype.paginate = function(options, callback) {
-  var defaults = {
+Query.prototype.paginate = async function (options) {
+  const defaults = {
     perPage: 10, // Number of items to display on each page.
-    delta  :  5, // Number of page numbers to display before and after the current one.
-    page   :  1, // Initial page number.
-    offset :  0  // Offset number.
+    delta: 5, // Number of page numbers to display before and after the current one.
+    page: 1, // Initial page number.
+    offset: 0, // Offset number.
   };
 
   options = options || defaults;
@@ -22,49 +22,42 @@ Query.prototype.paginate = function(options, callback) {
   options.page = options.page || defaults.page;
   options.offset = options.offset || defaults.offset;
 
-  var query = this;
-  var model = query.model;
-  model.count(query._conditions, function(err, count) {
-    var _skip = (options.page - 1) * options.perPage;
-    _skip += options.offset;
-    query.skip(_skip).limit(+options.perPage).exec(function(err, results) {
-      if (err) {
-        callback(err, {});
-        return;
-      }
+  const query = this;
+  const model = query.model;
 
-      results = results || [];
-      var page = parseInt(options.page, 10) || 0;
-      var delta = options.delta;
-      var offset_count = count - options.offset;
-      offset_count = offset_count > 0 ? offset_count : 0;
-      var last = Math.ceil(offset_count / options.perPage);
-      var current = page;
-      var start = page - delta > 1 ? page - delta : 1;
-      var end = current + delta + 1 < last ? current + delta : last;
+  const count = await model.count(query._conditions);
+  const _skip = (options.page - 1) * options.perPage + options.offset;
+  const results = await query.skip(_skip).limit(+options.perPage).exec();
 
-      var pages = [];
-      for (var i = start; i <= end; i++) {
-        pages.push(i);
-      }
+  results = results || [];
+  const page = parseInt(options.page, 10) || 0;
+  const delta = options.delta;
+  let offset_count = count - options.offset;
+  offset_count = offset_count > 0 ? offset_count : 0;
+  const last = Math.ceil(offset_count / options.perPage);
+  const current = page;
+  const start = page - delta > 1 ? page - delta : 1;
+  const end = current + delta + 1 < last ? current + delta : last;
 
-      var prev = !count || current == start ? null : current - 1;
-      var next = !count || current == end ? null : current + 1;
-      if (!offset_count) {
-        prev = next = last = null;
-      }
+  const pages = [];
+  for (let i = start; i <= end; i++) {
+    pages.push(i);
+  }
 
-      var pager = {
-        'results': results,
-        'options': options,
-        'current': current,
-        'last': last,
-        'prev': prev,
-        'next': next,
-        'pages': pages,
-        'count': count
-      };
-      callback(err, pager);
-    });
-  });
+  const prev = !count || current == start ? null : current - 1;
+  const next = !count || current == end ? null : current + 1;
+  if (!offset_count) {
+    prev = next = last = null;
+  }
+
+  return {
+    results: results,
+    options,
+    current,
+    last,
+    prev,
+    next,
+    pages,
+    count,
+  };
 };

--- a/test/test2.js
+++ b/test/test2.js
@@ -2,65 +2,60 @@
  * test
  */
 //var should = require('should');
-var assert = require('assert');
+var assert = require("assert");
 
-var mongoose = require('mongoose');
-require('../index');
+var mongoose = require("mongoose");
+require("../index");
 
-var conn = mongoose.createConnection('mongodb://localhost/query-test');
-//conn.db.dropDatabase();
+describe("paginate", function () {
+  let Comment;
+  let conn;
+  before(async function () {
+    conn = await mongoose.connect("mongodb://localhost/query-test");
 
-var CommentSchema = new mongoose.Schema({
-  number: Number,
-  name: String,
-  body: String
-});
-var Comment = conn.model('Comment', CommentSchema);
-
-describe('paginate', function() {
-
-  before(function(done) {
-    Comment.remove({}, function(err) {
-      var promises = [];
-      for (var i = 1; i <= 23; i++) {
-        promises.push(insert(i));
-      }
-
-      Promise.all(promises).then(function() {
-        done();
-      }, function(err) {
-        done(err);
-      });
+    const CommentSchema = new mongoose.Schema({
+      number: Number,
+      name: String,
+      body: String,
     });
+    Comment = conn.model("Comment", CommentSchema);
+    await Comment.deleteMany({});
+    const promises = [];
+    for (let i = 1; i <= 23; i++) {
+      promises.push(insert(i));
+    }
+
+    await Promise.all(promises);
 
     function insert(i) {
       return new Comment({
         number: i,
-        name: 'name' + i,
-        body: 'body' + i
+        name: "name" + i,
+        body: "body" + i,
       }).save();
     }
   });
 
-  after(function() {
-    conn.close();
+  after(async function () {
+    await conn.disconnect();
   });
 
- it('options.offset & page', function(done) {
-    Comment.find().paginate({offset: 2, perPage: 5, page: 5}, function(err, pager) {
-      assert.equal(pager.count, 23);
-      assert.equal(pager.last, 5);
-      done(err);
+  it("options.offset & page", async function () {
+    const pager = await Comment.find().paginate({
+      offset: 2,
+      perPage: 5,
+      page: 5,
     });
+    assert.equal(pager.count, 23);
+    assert.equal(pager.last, 5);
   });
-
- it('large options.offset', function(done) {
-    Comment.find().paginate({offset: 30, perPage: 5, page: 2}, function(err, pager) {
-      assert.equal(pager.count, 23);
-      assert.equal(pager.last, null);
-      done(err);
+  it("large options.offset", async function () {
+    const pager = await Comment.find().paginate({
+      offset: 30,
+      perPage: 5,
+      page: 2,
     });
+    assert.equal(pager.count, 23);
+    assert.equal(pager.last, null);
   });
-
-
 });


### PR DESCRIPTION
Mongoose does no longer support callbacks in recent versions. Time to upgrade the plugin to reflect those changes.

This PR:
1) upgrades the plugin to use `async await` instead of callbacks
2) upgrades the test suite to also use `async await`. 

Note that this is **breaking**, so I suggest a major version bump makes sense. 

**Test results:**
<img width="327" alt="Screenshot 2025-02-07 at 07 53 52" src="https://github.com/user-attachments/assets/481d9970-5eff-4b1d-9883-747874c3a6b0" />
<img width="295" alt="Screenshot 2025-02-07 at 07 54 02" src="https://github.com/user-attachments/assets/17cd0ba9-7859-4934-a478-fc936cd013c4" />
